### PR TITLE
Develop : エピソード投稿機能実装のためのAPIの作成

### DIFF
--- a/app/controllers/api/v1/episodes_controller.rb
+++ b/app/controllers/api/v1/episodes_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::EpisodesController < ApplicationController
+end

--- a/app/controllers/api/v1/episodes_controller.rb
+++ b/app/controllers/api/v1/episodes_controller.rb
@@ -1,2 +1,39 @@
 class Api::V1::EpisodesController < ApplicationController
+  def index
+    render json: Episode.all
+  end
+
+  def show
+    render json: Episode.find(params[:id])
+  end
+
+  def create
+    episode = Episode.new(episode_params)
+    if episode.save
+      render json: episode
+    else
+      render json: episode.errors, status: 422
+    end
+  end
+
+  def update
+    episode = Episode.find(params[:id])
+    if episode.update(episode_params)
+      render json: episode
+    else
+      render json: episode.errors, status: 422
+    end
+  end
+
+  def destroy
+    episode = Episode.find(params[:id])
+    episode.destroy
+    render json: episode
+  end
+
+  private
+
+  def episode_params
+    params.permit(:content)
+  end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::UsersController < ApplicationController
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::UsersController < ApplicationController
+  def show
+    render json: Episode.where(user_id: params[:id])
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,5 +3,5 @@ class ApplicationController < ActionController::API
   include ActionController::Helpers
 
   skip_before_action :verfy_authenticity_token, raise: false
-  helper_method :current_user, :user_signed_in?
+  helper_method :current_user, :user_signed_in?, :authenticate_user!
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,0 +1,2 @@
+class Episode < ApplicationRecord
+end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,2 +1,3 @@
 class Episode < ApplicationRecord
+  belong_to :user
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,3 +1,3 @@
 class Episode < ApplicationRecord
-  belong_to :user
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ActiveRecord::Base
          :rememberable,
          :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :episodes, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
+      resources :episodes
+      resources :users
+
       mount_devise_token_auth_for 'User',
                                   at: 'auth',
                                   controllers: {
@@ -11,8 +14,6 @@ Rails.application.routes.draw do
       namespace :auth do
         resources :sessions, only: %i[index]
       end
-
-      resources :episodes
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,14 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User',
                                   at: 'auth',
                                   controllers: {
-                                    registrations: 'api/v1/auth/registrations'
+                                    registrations: 'api/v1/auth/registrations',
                                   }
 
       namespace :auth do
         resources :sessions, only: %i[index]
       end
+
+      resources :episodes
     end
   end
 end

--- a/db/migrate/20211222203732_create_episodes.rb
+++ b/db/migrate/20211222203732_create_episodes.rb
@@ -1,0 +1,9 @@
+class CreateEpisodes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :episodes do |t|
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211224060208_add_columns_to_episodes.rb
+++ b/db/migrate/20211224060208_add_columns_to_episodes.rb
@@ -1,0 +1,5 @@
+class AddColumnsToEpisodes < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :episodes, :user, foreign_key: true, after: :content
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,35 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_22_024454) do
-  create_table 'users', force: :cascade do |t|
-    t.string 'provider', default: 'email', null: false
-    t.string 'uid', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.boolean 'allow_password_change', default: false
-    t.datetime 'remember_created_at'
-    t.string 'confirmation_token'
-    t.datetime 'confirmed_at'
-    t.datetime 'confirmation_sent_at'
-    t.string 'unconfirmed_email'
-    t.string 'name'
-    t.string 'email'
-    t.string 'birth_day'
-    t.string 'file_url'
-    t.text 'tokens'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['confirmation_token'],
-            name: 'index_users_on_confirmation_token',
-            unique: true
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'],
-            name: 'index_users_on_reset_password_token',
-            unique: true
-    t.index %w[uid provider],
-            name: 'index_users_on_uid_and_provider',
-            unique: true
+ActiveRecord::Schema.define(version: 2021_12_22_203732) do
+
+  create_table "episodes", force: :cascade do |t|
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "email"
+    t.string "birth_day"
+    t.string "file_url"
+    t.text "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,37 +10,45 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_22_203732) do
-
-  create_table "episodes", force: :cascade do |t|
-    t.text "content"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+ActiveRecord::Schema.define(version: 2021_12_24_060208) do
+  create_table 'episodes', force: :cascade do |t|
+    t.text 'content'
+    t.integer 'user_id'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['user_id'], name: 'index_episodes_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "provider", default: "email", null: false
-    t.string "uid", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.boolean "allow_password_change", default: false
-    t.datetime "remember_created_at"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.string "name"
-    t.string "email"
-    t.string "birth_day"
-    t.string "file_url"
-    t.text "tokens"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'provider', default: 'email', null: false
+    t.string 'uid', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.boolean 'allow_password_change', default: false
+    t.datetime 'remember_created_at'
+    t.string 'confirmation_token'
+    t.datetime 'confirmed_at'
+    t.datetime 'confirmation_sent_at'
+    t.string 'unconfirmed_email'
+    t.string 'name'
+    t.string 'email'
+    t.string 'birth_day'
+    t.string 'file_url'
+    t.text 'tokens'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['confirmation_token'],
+            name: 'index_users_on_confirmation_token',
+            unique: true
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'],
+            name: 'index_users_on_reset_password_token',
+            unique: true
+    t.index %w[uid provider],
+            name: 'index_users_on_uid_and_provider',
+            unique: true
   end
 
+  add_foreign_key 'episodes', 'users'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,46 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.create!(
+  name: 'test_user1',
+  email: 'test_mail1@example.com',
+  password: 'password',
+  password_confirmation: 'password',
+  birth_day: '2000-05-25',
+  file_url: 'https://e-code.s3.ap-northeast-1.amazonaws.com/test_image1.jpg',
+)
+User.create!(
+  name: 'test_user2',
+  email: 'test_mail2@example.com',
+  password: 'password',
+  password_confirmation: 'password',
+  birth_day: '2000-08-10',
+  file_url: 'https://e-code.s3.ap-northeast-1.amazonaws.com/test_image2.jpg',
+)
+
+test_user1 = User.find(1)
+episode1 =
+  Episode.create!(
+    content: 'これはテスト用のエピソードです(1)',
+    user: test_user1,
+  )
+
+episode2 =
+  Episode.create!(
+    content: 'これはテスト用のエピソードです(2)',
+    user: test_user1,
+  )
+
+test_user2 = User.find(2)
+episode3 =
+  Episode.create!(
+    content: 'これはテスト用のエピソードです(3)',
+    user: test_user2,
+  )
+
+episode4 =
+  Episode.create!(
+    content: 'これはテスト用のエピソードです(4)',
+    user: test_user2,
+  )

--- a/test/controllers/api/v1/episodes_controller_test.rb
+++ b/test/controllers/api/v1/episodes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::EpisodesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/episodes.yml
+++ b/test/fixtures/episodes.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+
+two:
+  content: MyText

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EpisodeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
* エピソードを閲覧、投稿、編集、削除するためのAPIの作成
* EpisodeとUserの紐づけ
* ログインしているユーザー以外が編集、削除を行うのを禁止

# メモ
* カラムの追加
```
rails generate migration AddColumnExample
```
とすることでカラムを追加することができる

* 関連付け
app/models/episode.rb
```
belongs_to :user
```
belongs_to :userでEpisodeに対して、Userが一対一の関連であることを表す

app/models/user.rb
```
has_many :episodes, dependent: :destroy
```
has_manyでUserに対して、Episodeが一対多の関連であることを表す。
また、dependent: :destroyと設定することで、Userが削除されたときに関連するEpisodeも削除される。

# 参考
[Active Record の関連付け](https://railsguides.jp/association_basics.html)
[Active Record マイグレーション](https://railsguides.jp/active_record_migrations.html)
[heartcombo / devise](https://github.com/heartcombo/devise)
