### PR TITLE
Develop : database.ymlを更新

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,6 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+    adapter: postgresql
+    encoding: unicode
+    pool: 5


### PR DESCRIPTION
# 概要
* database.ymlを更新するのを忘れていたので変更。

# Heroku エラー
```
Failed to install gems via Bundler.
Detected sqlite3 gem which is not supported on Heroku:
https://devcenter.heroku.com/articles/sqlite3
```